### PR TITLE
Fix #7 volume not started because of salt version

### DIFF
--- a/glusterfs/server/setup.sls
+++ b/glusterfs/server/setup.sls
@@ -58,14 +58,18 @@ glusterfs_vol_{{ name }}:
 {%- endif %}
 
 glusterfs_vol_{{ name }}_start:
+  {%- if force_compatibility %}
+  cmd.run:
+    - name: gluster volume start {{ name }}
+    - unless: gluster volume info {{ name }} | grep "Status: Started"
+    - require:
+      - cmd: glusterfs_vol_{{ name }}
+  {%- else %}
   glusterfs.started:
     - name: {{ name }}
     - require:
-      {%- if force_compatibility %}
-      - cmd: glusterfs_vol_{{ name }}
-      {%- else %}
       - glusterfs: glusterfs_vol_{{ name }}
-      {%- endif %}
+  {%- endif %}
 
 {%- if volume.options is defined %}
 {%- for key, value in volume.options.iteritems() %}


### PR DESCRIPTION
glusterfs.started module does not work with older salt version minions.
This patch checks for whether salt minion is older than 2016.3.0 and if
so utilizes cmd.run instead of glusterfs.started.

Without this patch older salt minions will throw the following error:
```
An exception occurred in this state: Traceback (most recent call last):
File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1628, in call
  **cdata['kwargs'])
File "/usr/lib/python2.7/dist-packages/salt/loader.py", line 1494, in wrapper
  return f(*args, **kwargs)
File "/usr/lib/python2.7/dist-packages/salt/states/glusterfs.py", line 209, in started
  if isinstance(__salt__['glusterfs.status'](name), dict):
File "/usr/lib/python2.7/dist-packages/salt/modules/glusterfs.py", line 315, in status
  root = _gluster_xml('volume status {0}'.format(name))
File "/usr/lib/python2.7/dist-packages/salt/modules/glusterfs.py", line 86, in _gluster_xml
  raise CommandExecutionError(root.find('opErrstr').text)
```

Original code came from GitHub user @AlexPostID. Modified by @Samos123
to use force_compatibility flag and fix issue of hardcoded keystone-keys.

Co-Author: Aleksei Shishkin(AlexPostID)