### PR TITLE
Fix unless condition in setup.sls

### DIFF
--- a/glusterfs/server/setup.sls
+++ b/glusterfs/server/setup.sls
@@ -61,7 +61,7 @@ glusterfs_vol_{{ name }}_start:
   {%- if force_compatibility %}
   cmd.run:
     - name: gluster volume start {{ name }}
-    - unless: gluster volume info {{ name }} | grep "Status: Started"
+    - unless: "gluster volume info {{ name }} | grep 'Status: Started'"
     - require:
       - cmd: glusterfs_vol_{{ name }}
   {%- else %}


### PR DESCRIPTION
During glusterfs.server.setup run this error occured, this seems to be cause by invalid syntax in unless condition

```
    Data failed to compile:
----------
    Rendering SLS 'base:glusterfs.server.setup' failed: mapping values are not allowed here; line 24

---
[...]
    - unless: "gluster volume info glance"

glusterfs_vol_glance_start:
  cmd.run:
    - name: gluster volume start glance
    - unless: gluster volume info glance | grep "Status: Started"    <======================
    - require:
      - cmd: glusterfs_vol_glance

glusterfs_vol_glance_diagnostics.brick-log-level:
  cmd.run:
[...]
---
```